### PR TITLE
add search to queryparams and reset all filters except (lang, sort_or…

### DIFF
--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -148,7 +148,14 @@ export default {
       this.$router.push({query})
     },
     updateSearch: function(search) {
-      this.updateRouterParam({search: search})
+      const settings = {
+        search: search,
+        topic: undefined,
+        show_free: undefined,
+        sub_topics: undefined,
+        mediatype: undefined
+      }
+      this.updateRouterParam(settings)
     },
     updateSortOrderSelected: function (sort_order) {
       this.updateRouterParam({sort_order: sort_order});


### PR DESCRIPTION
add search to queryparams and reset all filters except (lang, sort_order)


test 1
- add selections using filters (topic, sub_topics, show_free, mediatype) 
- enter text in searchinput and submit
- selections should now be reset (except lang, sort_order)
- a new queryparam should now be visible with search="bar") 

test 2 
- enter text in searchinput 
- submit
- apply filters after search (this should update queryparams) 

test 3
- Enter text in searchinput 
- submit
- select filters 
- click the x to clear search (this should clear filters and search string