### PR TITLE
Empty string is now stored instead of nil in database malfunction_mes…

### DIFF
--- a/backend-admin/lib/db_list_admin/model/database.ex
+++ b/backend-admin/lib/db_list_admin/model/database.ex
@@ -94,7 +94,8 @@ defmodule DbListAdmin.Model.Database do
       :access_information_code,
       :malfunction_message_active,
       :malfunction_message,
-      ])
+      ],
+      [empty_values: [nil]])
     |> validate_required([:title_en, :title_sv])
     |> unique_constraint(:title_en, name: :database_title_en_key)
     |> unique_constraint(:title_sv, name: :database_title_sv_key)


### PR DESCRIPTION
…sage when empty string is passed as value.